### PR TITLE
Compatibility with the silverstripe-comments module

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -15,6 +15,10 @@ Object::useCustomClass('MemberLoginForm', 'FoundationMemberLoginForm');
 if (class_exists('UserDefinedForm')) {
 	Object::add_extension('UserDefinedForm_Controller', 'FoundationUserDefinedForm_Controller');
 }
+// TODO Opt-in Use
+if (class_exists('CommentingController')) {
+	Object::add_extension('CommentingController', 'FoundationCommentingController');
+}
 
 // TODO Decorate Fields
 //Object::add_extension("FormField", "FoundationFormField");

--- a/code/FoundationCommentingController.php
+++ b/code/FoundationCommentingController.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Performs the FoundationFormTransformation on CommentingController
+ * @author Anselm Christophersen <ac@anselm.dk>
+ * @package foundation_forms
+ */
+class FoundationCommentingController extends DataExtension {
+
+	public function alterCommentForm(Form $form) {
+		$form->transform(new FoundationFormTransformation());
+		$form->setTemplate('FoundationCommentingControllerForm', 'FoundationForm', 'Form');
+		$form->addExtraClass('custom');
+	}
+
+}

--- a/code/FoundationFormTransformation.php
+++ b/code/FoundationFormTransformation.php
@@ -25,6 +25,11 @@ class FoundationFormTransformation extends FormTransformation {
 			$field->FieldList()->transform(new FoundationFormTransformation());
 		}
 		
+		// compositefield
+		if ($field instanceof CompositeField) {
+			$field->FieldList()->transform(new FoundationFormTransformation());
+		}
+		
 		$template = "Foundation{$field->class}_holder";
 			
 		if (SSViewer::hasTemplate($template)) {

--- a/templates/forms/FoundationCompositeField.ss
+++ b/templates/forms/FoundationCompositeField.ss
@@ -1,0 +1,15 @@
+<$Tag class="CompositeField $extraClass <% if ColumnCount %>multicolumn<% end_if %>">
+<% if $Tag == 'fieldset' && $Legend %>
+	<legend>$Legend</legend>
+<% end_if %>
+
+<% loop $FieldList %>
+	<% if $ColumnCount %>
+		<div class="column-{$ColumnCount} $FirstLast">
+			$FieldHolder
+		</div>
+	<% else %>
+		$FieldHolder
+	<% end_if %>
+<% end_loop %>
+</$Tag>


### PR DESCRIPTION
`CommentingController` on https://github.com/silverstripe/silverstripe-comments uses a `CompositeField` which yet remained to be added in the module.
See below for before and after screenshots:

![screenshot 2015-01-07 14 54 23](https://cloud.githubusercontent.com/assets/1316533/5646641/e6e63dea-967e-11e4-83ff-0b2c14afa029.png)

![screenshot 2015-01-07 14 54 46](https://cloud.githubusercontent.com/assets/1316533/5646644/ee06c950-967e-11e4-8e95-615c77c18ed2.png)
